### PR TITLE
Add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Time-Based Storage System
 
+[![CI](https://github.com/johnburbridge/python-time-based-experiment/actions/workflows/ci.yml/badge.svg)](https://github.com/johnburbridge/python-time-based-experiment/actions/workflows/ci.yml)
+
 A Python package providing two implementations of a time-based storage system for managing events with timestamps.
 
 ## Features


### PR DESCRIPTION
This PR adds a CI badge to the README.md file to show the current status of the CI workflow and make it easily accessible.